### PR TITLE
Thymeleafを使った更新処理を実装

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -8,10 +8,12 @@ import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import raisetech.StudentManagement.controller.converter.StudentConverter;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourses;
+import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.domain.StudentForm;
 import raisetech.StudentManagement.service.StudentService;
 
@@ -36,17 +38,20 @@ public class StudentController {
     return "studentList";
   }
 
-  @GetMapping("/studentsCoursesList")
-  public List<StudentCourses> getStudentcoursesList() {
-    return service.getStudentCourses();
-  }
-
   @GetMapping("newStudent")
   public String newStudent(Model model) {
     StudentForm studentForm = new StudentForm();
     model.addAttribute("studentForm", studentForm);
     return "registerStudent";
   }
+
+  @GetMapping("/student/{id}")
+  public String getStudentById(@PathVariable String id, Model model) {
+    StudentDetail studentDetail = service.getStudentDetailById(id);
+    model.addAttribute("studentDetail", studentDetail);
+    return "updateStudent";
+  }
+
 
   @PostMapping("/registerStudent")
   public String registerStudent(@Valid @ModelAttribute StudentForm studentForm,
@@ -62,6 +67,24 @@ public class StudentController {
       return "/registerStudent";
     }
     service.registerStudent(studentForm);
+    return "redirect:/studentList";
+  }
+
+  @PostMapping("/updateStudent")
+  public String updateStudent(@Valid @ModelAttribute StudentDetail studentDetail,
+      BindingResult result) {
+
+    if (result.hasErrors()) {
+      System.out.println("バリデーションエラーあり");
+      result.getFieldErrors().forEach(error -> {
+            System.out.println("エラー項目：" + error.getField());
+            System.out.println("メッセージ：" + error.getDefaultMessage());
+          }
+      );
+      return "/updateStudent";
+    }
+
+    service.updateStudent(studentDetail);
     return "redirect:/studentList";
   }
 }

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -1,6 +1,9 @@
 package raisetech.StudentManagement.controller;
 
 import jakarta.validation.Valid;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -84,7 +87,15 @@ public class StudentController {
       return "/updateStudent";
     }
 
+    String encodeName = "";
+    try {
+      encodeName = URLEncoder.encode(studentDetail.getStudent().getName(),
+          StandardCharsets.UTF_8.toString());
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException("エンコードエラーが発生しました", e);
+    }
+
     service.updateStudent(studentDetail);
-    return "redirect:/studentList";
+    return "redirect:/studentList?updated=true&name=" + encodeName;
   }
 }

--- a/src/main/java/raisetech/StudentManagement/repositry/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repositry/StudentRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourses;
 
@@ -14,11 +15,16 @@ import raisetech.StudentManagement.data.StudentCourses;
 public interface StudentRepository {
 
   @Select("SELECT * FROM students")
-  List<Student> search();
+  List<Student> searchStudents();
 
+  @Select("SELECT * FROM students WHERE id = #{id}")
+  Student searchByIdStudent(String id);
 
   @Select("SELECT * from students_courses")
   List<StudentCourses> searchCourses();
+
+  @Select("SELECT * from students_courses WHERE student_id = #{studentId}")
+  List<StudentCourses> searchCoursesByStudentId(String studentId);
 
   @Insert("INSERT INTO students (id, name, kana, nickname, email, area, age, gender, remark, is_deleted) VALUES (#{id},#{name},#{kana},#{nickname},#{email},#{area},#{age},#{gender},#{remark},#{isDeleted})")
   void registerStudent(Student student);
@@ -28,4 +34,10 @@ public interface StudentRepository {
           + "(#{id},#{studentId}, #{courseName}, #{courseStartDate}, #{expectedEndDateOfTheCourse})"
   )
   void registerStudentCourse(StudentCourses studentCourses);
+
+  @Update("UPDATE students SET name = #{name}, kana = #{kana}, nickname = #{nickname}, email = #{email}, area = #{area}, age = #{age}, gender = #{gender}, remark = #{remark}, is_deleted = #{isDeleted} WHERE id = #{id}")
+  void updateStudent(Student student);
+
+  @Update("UPDATE students_courses SET  course_name = #{courseName} WHERE student_id = #{studentId}")
+  void updateStudentCourse(StudentCourses studentCourses);
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -18,7 +18,7 @@ public class StudentService {
   }
 
   public List<Student> getStudents() {
-    return repository.search();
+    return repository.searchStudents();
   }
 
   public List<StudentCourses> getStudentCourses() {

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourses;
+import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.domain.StudentForm;
 import raisetech.StudentManagement.repositry.StudentRepository;
 
@@ -25,6 +26,16 @@ public class StudentService {
     return repository.searchCourses();
   }
 
+  public StudentDetail getStudentDetailById(String id) {
+
+    StudentDetail studentDetail = new StudentDetail();
+    Student student = repository.searchByIdStudent(id);
+    List<StudentCourses> studentCourses = repository.searchCoursesByStudentId(id);
+    studentDetail.setStudent(student);
+    studentDetail.setStudentCourses(studentCourses);
+    return studentDetail;
+  }
+
   public void registerStudent(StudentForm studentForm) {
 
     Student registerStudent = new Student(UUID.randomUUID().toString(), studentForm.getStudent());
@@ -33,5 +44,14 @@ public class StudentService {
 
     repository.registerStudent(registerStudent);
     repository.registerStudentCourse(registerStudentCourses);
+  }
+
+  public void updateStudent(StudentDetail studentDetail) {
+
+    repository.updateStudent(studentDetail.getStudent());
+    for (StudentCourses studentCourses : studentDetail.getStudentCourses()) {
+      studentCourses.setStudentId(studentDetail.getStudent().getId());
+      repository.updateStudentCourse(studentCourses);
+    }
   }
 }

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -31,7 +31,10 @@
   <tbody>
   <tr th:each="studentDetails : ${studentList}">
     <td th:text="${studentDetails.student.id}">1</td>
-    <td th:text="${studentDetails.student.name}">山田太郎</td>
+    <td>
+      <a th:href="@{/student/{id}(id=${studentDetails.student.id})}"
+         th:text="${studentDetails.student.name}">山田太郎</a>
+    </td>
     <td th:text="${studentDetails.student.kana}">ヤマダタロウ</td>
     <td th:text="${studentDetails.student.nickname}">タロー</td>
     <td th:text="${studentDetails.student.email}">taro@icloud.com</td>
@@ -65,4 +68,3 @@
 </table>
 </body>
 </html>
-

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -7,10 +7,42 @@
     ul {
       list-style: none;
     }
+
+    .alert {
+    background-color: #d4edda; /* うすい緑 */
+    color: #155724; /* 文字は濃い緑 */
+    padding: 1em;
+    margin-bottom: 1em;
+    border: 1px solid #c3e6cb;
+    border-radius: 5px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    width: 19%; /* 画面の幅の50%だけにする */
+
+  }
+
+  .alert button {
+    background: none;
+    border: none;
+    font-size: 1.2em;
+    color: #155724;
+    cursor: pointer;
+  }
+
   </style>
 </head>
 <body>
 <h1>受講生一覧</h1>
+
+<div th:if="${param.updated}" class="alert" id="updateMessage">
+  <span
+      th:text="${param.name} + ' さんの学生情報を更新しました！'">○○さんの学生情報を更新しました！</span>
+  <button type="button" onclick="closeMessage()">×</button>
+</div>
+
+
 <table border="1">
   <thead>
   <tr>
@@ -64,6 +96,16 @@
     </td>
     <td th:text="${studentDetails.student.remark}">特になし</td>
   </tr>
+
+  <script>
+    function closeMessage() {
+      const message = document.getElementById('updateMessage');
+      if (message) {
+        message.style.display = 'none';
+      }
+    }
+  </script>
+
   </tbody>
 </table>
 </body>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生詳細詳細</title>
+
+  <style>
+    .error-message {
+      color: red;
+      font-size: 0.9em;
+      margin-top: 4px;
+    }
+  </style>
+
+</head>
+</head>
+<body>
+<h1>受講生情報詳細</h1>
+<form th:action="@{/updateStudent}" th:object="${studentDetail}" method="post">
+  <input type="hidden" th:field="*{student.id}" />
+  <table>
+
+    <tr>
+      <th><label for="name">名前：</label></th>
+      <td>
+        <input type="text" id="name" th:field="*{student.name}"/>
+      </td>
+    </tr>
+    <tr>
+      <th></th>
+      <td>
+        <div th:if="${#fields.hasErrors('student.name')}"
+             th:errors="*{student.name}"
+             class="error-message"></div>
+      </td>
+    </tr>
+
+    <tr>
+      <th><label for="kana">フリガナ：</label></th>
+      <td>
+        <input type="text" id="kana" th:field="*{student.kana}"/>
+      </td>
+    </tr>
+    <tr>
+      <th></th>
+      <td>
+        <div th:if="${#fields.hasErrors('student.kana')}"
+             th:errors="*{student.kana}"
+             class="error-message"></div>
+      </td>
+    </tr>
+
+    <tr>
+      <th><label for="nickName">ニックネーム：</label></th>
+      <td>
+        <input type="text" id="nickName" th:field="*{student.nickname}"/>
+      </td>
+    </tr>
+
+    <tr>
+      <th><label for="email">メールアドレス：</label></th>
+      <td>
+        <input type="text" id="email" th:field="*{student.email}"/>
+      </td>
+    </tr>
+    <tr>
+      <th></th>
+      <td>
+        <div th:if="${#fields.hasErrors('student.email')}"
+             th:errors="*{student.email}"
+             class="error-message"></div>
+      </td>
+    </tr>
+
+    <tr th:each="course, stat : *{studentCourses}">
+      <th><label th:for="|studentCourses[${stat.index}].courseName|">コース名：</label></th>
+      <td>
+        <input type="text"
+               th:id="|studentCourses[${stat.index}].courseName|"
+               th:field="*{studentCourses[__${stat.index}__].courseName}" />
+        <div th:if="${#fields.hasErrors('studentCourses[' + stat.index + '].courseName')}"
+             th:errors="*{studentCourses[__${stat.index}__].courseName}"
+             class="error-message"></div>
+      </td>
+    </tr>
+
+    <tr>
+      <th><label for="area">居住地：</label></th>
+      <td>
+        <input type="text" id="area" th:field="*{student.area}" />
+      </td>
+    </tr>
+
+    <tr>
+      <th><label for="age">年齢：</label></th>
+      <td>
+        <input type="text" id="age" th:field="*{student.age}" />
+      </td>
+    </tr>
+
+    <tr>
+      <th><label for="gender">性別：</label></th>
+      <td>
+        <input type="text" id="gender" th:field="*{student.gender}" />
+      </td>
+    </tr>
+
+    <tr>
+      <th><label for="remark">備考：</label></th>
+      <td>
+        <input type="text" id="remark" th:field="*{student.remark}" />
+      </td>
+    </tr>
+
+  </table>
+  <button type="submit">更新</button>
+</form>
+</body>
+</html>


### PR DESCRIPTION
### ◎受講生情報の更新処理の実装

お疲れ様です。
今回は、学生情報とコース情報のUPDATE処理の実装ができましたので、
ご確認よろしくお願いいたします。


## ◎実行結果

### 更新処理結果の動画になります。
 
https://github.com/user-attachments/assets/e01263e7-d248-4315-8972-aaf8c22db06a

### それぞれの画面の説明


#### ○学生一覧画面

 
![スクリーンショット 2025-04-28 203900](https://github.com/user-attachments/assets/82ee412d-617e-43a1-b3ee-c3effe298fd5)

 
#### ○更新完了後受講生一覧画面 
- 学生情報詳細画面で情報を更新して「更新」ボタンを押すと、受講生一覧画面に画面遷移し、タイトルの下に「更新した受講生の名前＋さんの学生情報詳細を更新しました。」という完了メッセージを表示するようにしています。
- メッセージは右端の×ボタンを押すと消えるようになっています。

![スクリーンショット 2025-04-28 203936](https://github.com/user-attachments/assets/cab2da32-4fcb-4a49-be89-d5d168e4276d)


### ◎一点質問です。

学生情報詳細画面の更新処理について相談です。

現在、画面側で使用しているインスタンスでは、持っていないフィールドが存在しているため、更新処理をしてもバリデーションエラーになってしまいます。


この問題を解決する方法として、調べた中で次の3つのどれがよろしいのでしょうか？

①バリデーショングループを使う方法
　（グループインターフェースを作り、エンティティにグループを割り当てる）

②更新処理用の別クラス（DTO）を作成する方法

③画面で隠しフィールドとして不足フィールドを持たせる方法


自分の中では、①か②かなと思っています。

①バリデーショングループを使う方法の方は、別クラスを作らずに、登録処理と更新処理のバリデーションの切り替えが出来るので、シンプルでとてもいいなと思いました。

②更新処理用の別クラス（DTO）を作成する方法は、新たにクラスを作る手間がありますが、クラスごとの役割が分かりやすくなるので、いいなと思いました



